### PR TITLE
17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
 
     name: "Build for Android ${{matrix.arch}}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.1
-    - name: set up python 3.12.3    
+    - name: set up python  
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12.3' 
+        python-version: '3.13.0-beta.3' 
     - name: set up JDK 17
       uses: actions/setup-java@v4.1.0
       with:
@@ -47,7 +47,7 @@ jobs:
 
   pojav:
     needs: build_android
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4.1.1

--- a/android-wrapped-clang
+++ b/android-wrapped-clang
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [[ "$1" = "--version" ]]; then
   echo "${TARGET}-gcc (GCC) 14.1 20240507 (release)"
-  echo "Copyright (C) 2014 Free Software Foundation, Inc."
+  echo "Copyright (C) Free Software Foundation, Inc."
   echo "This is free software; see the source for copying conditions.  There is NO"
   echo "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
 else

--- a/android-wrapped-clang
+++ b/android-wrapped-clang
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [[ "$1" = "--version" ]]; then
-  echo "${TARGET}-gcc (GCC) 4.9 20140827 (prerelease)"
+  echo "${TARGET}-gcc (GCC) 14.1 20240507 (release)"
   echo "Copyright (C) 2014 Free Software Foundation, Inc."
   echo "This is free software; see the source for copying conditions.  There is NO"
   echo "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."

--- a/android-wrapped-clang++
+++ b/android-wrapped-clang++
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [[ "$1" = "--version" ]]; then
-  echo "${TARGET}-g++ (GCC) 4.9 20140827 (prerelease)"
-  echo "Copyright (C) 2014 Free Software Foundation, Inc."
+  echo "${TARGET}-g++ (GCC) 14.1 20240507 (release)"
+  echo "Copyright (C) Free Software Foundation, Inc."
   echo "This is free software; see the source for copying conditions.  There is NO"
   echo "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
 else

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -3,7 +3,7 @@ set -e
 . setdevkitpath.sh
 
 export FREETYPE_DIR=$PWD/freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT
-export CUPS_DIR=$PWD/cups-2.4.7
+export CUPS_DIR=$PWD/cups
 export CFLAGS+=" -DLE_STANDALONE -Wno-int-conversion -Wno-error=implicit-function-declaration" # -I$FREETYPE_DIR -I$CUPS_DI
 if [[ "$TARGET_JDK" == "arm" ]]
 then

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -4,7 +4,7 @@ set -e
 
 export FREETYPE_DIR=$PWD/freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT
 export CUPS_DIR=$PWD/cups-2.4.7
-export CFLAGS+=" -DLE_STANDALONE" # -I$FREETYPE_DIR -I$CUPS_DI
+export CFLAGS+=" -DLE_STANDALONE -Wno-int-conversion -Wno-error=implicit-function-declaration" # -I$FREETYPE_DIR -I$CUPS_DI
 if [[ "$TARGET_JDK" == "arm" ]]
 then
   export CFLAGS+=" -O3 -D__thumb__"
@@ -12,7 +12,7 @@ else
   if [[ "$TARGET_JDK" == "x86" ]]; then
      export CFLAGS+=" -O3 -mstackrealign"
   else
-     export CFLAGS+=" -O3"
+     export CFLAGS+=" -O3 -flto=auto"
   fi
 fi
 
@@ -35,13 +35,9 @@ platform_args="--with-toolchain-type=gcc \
   --with-freetype-include=$FREETYPE_DIR/include/freetype2 \
   --with-freetype-lib=$FREETYPE_DIR/lib \
   OBJCOPY=${OBJCOPY} \
-  RANLIB=${RANLIB} \
-  LINK=${LINK} \
   AR=${AR} \
-  AS=${AS} \
   NM=${NM} \
   STRIP=${STRIP} \
-  READELF=${READELF} \
   "
 AUTOCONF_x11arg="--x-includes=$ANDROID_INCLUDE/X11"
 AUTOCONF_EXTRA_ARGS+="OBJCOPY=$OBJCOPY \
@@ -91,6 +87,16 @@ bash ./configure \
     --with-fontconfig-include=$ANDROID_INCLUDE \
     $AUTOCONF_x11arg $AUTOCONF_EXTRA_ARGS \
     --x-libraries=/usr/lib \
+    OBJDUMP=${OBJDUMP} \
+    STRIP=${STRIP} \
+    NM=${NM} \
+    AR=${AR} \
+    OBJCOPY=${OBJCOPY} \
+    CXXFILT=${CXXFILT} \
+    BUILD_NM=${NM} \
+    BUILD_AR=${AR} \
+    BUILD_OBJCOPY=${OBJCOPY} \
+    BUILD_STRIP=${STRIP} \
         $platform_args || \
 error_code=$?
 if [[ "$error_code" -ne 0 ]]; then

--- a/getlibs.sh
+++ b/getlibs.sh
@@ -6,6 +6,4 @@ set -e
 
 wget https://downloads.sourceforge.net/project/freetype/freetype2/$BUILD_FREETYPE_VERSION/freetype-$BUILD_FREETYPE_VERSION.tar.gz
 tar xf freetype-$BUILD_FREETYPE_VERSION.tar.gz
-wget https://github.com/OpenPrinting/cups/releases/download/v2.4.7/cups-2.4.7-source.tar.gz
-tar xf cups-2.4.7-source.tar.gz
-rm cups-2.4.7-source.tar.gz freetype-$BUILD_FREETYPE_VERSION.tar.gz
+git clone --depth 1 https://github.com/OpenPrinting/cups

--- a/makejdkwithoutconfigure.sh
+++ b/makejdkwithoutconfigure.sh
@@ -4,7 +4,7 @@
 set -e
 . setdevkitpath.sh
 export FREETYPE_DIR=`pwd`/freetype-${BUILD_FREETYPE_VERSION}/build_android-${TARGET_SHORT}
-export CUPS_DIR=`pwd`/cups-2.4.7
+export CUPS_DIR=`pwd`/cups
 
 cd openjdk/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-release
 make JOBS=$(nproc) images

--- a/patches/jdk17u_android.diff
+++ b/patches/jdk17u_android.diff
@@ -214,7 +214,8 @@ index 5cba93178..181e0db5c 100644
  
 -ifeq ($(call isTargetOs, linux), true)
 +ifeq ($(call isTargetOs, android linux), true)
-   DUMP_SYMBOLS_CMD := $(NM) --defined-only *.o
+-  DUMP_SYMBOLS_CMD := $(NM) --defined-only *.o
++  DUMP_SYMBOLS_CMD := $(NM) --defined-only --extern-only *.o
    ifneq ($(FILTER_SYMBOLS_PATTERN), )
      FILTER_SYMBOLS_PATTERN := $(FILTER_SYMBOLS_PATTERN)|
 diff --git a/make/hotspot/lib/JvmOverrideFiles.gmk b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -268,7 +269,7 @@ index 4d0c0c00d..0bd1b5063 100644
      LDFLAGS_aix := -Wl$(COMMA)-berok, \
      LIBS := $(BUILD_LIBFONTMANAGER_FONTLIB), \
 -    LIBS_unix := -lawt -ljava -ljvm $(LIBM) $(LIBCXX), \
-+    LIBS_unix := -lawt -lawt_headless -ljava -ljvm $(LIBM) $(LIBCXX), \
++    LIBS_unix := -lawt -lawt_headless -ljava -ljvm -lc $(LIBM) $(LIBCXX), \
      LIBS_macosx := -lawt_lwawt -framework CoreText -framework CoreFoundation -framework CoreGraphics, \
      LIBS_windows := $(WIN_JAVA_LIB) advapi32.lib user32.lib gdi32.lib \
          $(WIN_AWT_LIB), \
@@ -277,7 +278,7 @@ index 4d0c0c00d..0bd1b5063 100644
    ))
  
 -  TARGETS += $(BUILD_LIBSPLASHSCREEN)
-+  # TARGETS += $(BUILD_LIBSPLASHSCREEN)
++  # TARGETS += $(BUILD_LIBAWT_XAWT)
  
    ifeq ($(call isTargetOs, macosx), true)
      $(BUILD_LIBSPLASHSCREEN): $(call FindLib, $(MODULE), osxapp)
@@ -417,7 +418,7 @@ index ae0c73dcb..e2c9a21f7 100644
  }
  
  /////////////////////////////////////////////////////////////////////////////
-@@ -1374,7 +1382,13 @@ const char* os::dll_file_extension() { return ".so"; }
+@@ -1374,6 +1382,12 @@ const char* os::dll_file_extension() { return ".so"; }
  
  // This must be hard coded because it's the system's temporary
  // directory not the java application's temp directory, ala java.io.tmpdir.
@@ -430,8 +431,7 @@ index ae0c73dcb..e2c9a21f7 100644
 +#endif
 +}
  
- static bool file_exists(const char* filename) {
-   struct stat statbuf;
+ // check if addr is inside libjvm.so
 @@ -1517,6 +1531,30 @@ bool os::dll_address_to_library_name(address addr, char* buf,
    return false;
  }
@@ -2338,7 +2338,7 @@ index 68835987b..eafd4509e 100644
  #ifndef NET_UTILS_MD_H
  #define NET_UTILS_MD_H
  
-+#ifdef ANDROID
++#ifdef __ANDROID__
 +#include <netinet/in.h>
 +#endif
  #include <netdb.h>
@@ -2568,3 +2568,21 @@ index be578a0bb..ce5e8b400 100644
 +#if !defined(__GLIBC__) && !defined(__ANDROID__)
  // Alpine doesn't know these types, define them
  typedef unsigned int       __uint32_t;
+diff --git a/make/data/hotspot-symbols/symbols-aix b/make/data/hotspot-symbols/symbols-aix
+index 92703573a5f5..11dad0fece50 100644
+--- a/make/data/hotspot-symbols/symbols-aix
++++ b/make/data/hotspot-symbols/symbols-aix
+@@ -24,4 +24,3 @@
+ JVM_handle_aix_signal
+ numa_error
+ numa_warn
+-sysThreadAvailableStackWithSlack
+diff --git a/make/data/hotspot-symbols/symbols-linux b/make/data/hotspot-symbols/symbols-linux
+index bbb0d35115fc..b0d802f1773f 100644
+--- a/make/data/hotspot-symbols/symbols-linux
++++ b/make/data/hotspot-symbols/symbols-linux
+@@ -25,4 +25,3 @@ JVM_handle_linux_signal
+ JVM_IsUseContainerSupport
+ numa_error
+ numa_warn
+-sysThreadAvailableStackWithSlack

--- a/removejdkdebuginfo.sh
+++ b/removejdkdebuginfo.sh
@@ -8,7 +8,7 @@ imagespath=openjdk/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-${JDK_DEB
 rm -rf dizout jreout jdkout dSYM-temp
 mkdir -p dizout dSYM-temp/{lib,bin}
 
-cp freetype/build_android-$TARGET_SHORT/lib/libfreetype.so $imagespath/jdk/lib/
+cp freetype-${BUILD_FREETYPE_VERSION}/build_android-$TARGET_SHORT/lib/libfreetype.so $imagespath/jdk/lib/
 
 cp -r $imagespath/jdk jdkout
 
@@ -38,8 +38,8 @@ $JLINK_STRIP_ARG \
 --release-info=jdkout/release \
 --compress=0 
 
-cp freetype/build_android-$TARGET_SHORT/lib/libfreetype.so jreout/lib/
-cp freetype/build_android-$TARGET_SHORT/lib/libfreetype.so jdkout/lib/
+cp freetype-${BUILD_FREETYPE_VERSION}/build_android-$TARGET_SHORT/lib/libfreetype.so jreout/lib/
+cp freetype-${BUILD_FREETYPE_VERSION}/build_android-$TARGET_SHORT/lib/libfreetype.so jdkout/lib/
 
 # mv jreout/lib/${TARGET_JDK}/libfontmanager.diz jreout/lib/${TARGET_JDK}/libfontmanager.diz.keep
 # find jreout -name "*.debuginfo" | xargs -- rm

--- a/removejdkdebuginfo.sh
+++ b/removejdkdebuginfo.sh
@@ -3,20 +3,22 @@ set -e
 
 . setdevkitpath.sh
 
-targetpath=openjdk/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-${JDK_DEBUG_LEVEL}
+imagespath=openjdk/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-${JDK_DEBUG_LEVEL}/images
 
 rm -rf dizout jreout jdkout dSYM-temp
 mkdir -p dizout dSYM-temp/{lib,bin}
 
-cp freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT/lib/libfreetype.so $targetpath/images/jdk/lib/
+cp freetype/build_android-$TARGET_SHORT/lib/libfreetype.so $imagespath/jdk/lib/
 
-cp -r $targetpath/images/jdk jdkout
+cp -r $imagespath/jdk jdkout
 
 # JDK no longer create separate JRE image, so we have to create one manually.
 #mkdir -p jreout/bin
 #cp jdkout/bin/{java,jfr,keytool,rmiregistry} jreout/bin/
 #cp -r jdkout/{conf,legal,lib,man,release} jreout/
 #rm jreout/lib/src.zip
+
+export EXTRA_JLINK_OPTION=
 
 if [[ "$TARGET_JDK" == "aarch64" ]] || [[ "$TARGET_JDK" == "x86_64" ]]; then
    echo "Building for aarch64 or x86_64, introducing JVMCI module"
@@ -26,18 +28,18 @@ fi
 # Produce the jre equivalent from the jdk (https://blog.adoptium.net/2021/10/jlink-to-produce-own-runtime/)
 export JLINK_STRIP_ARG="--strip-native-debug-symbols=exclude-debuginfo-files:objcopy=${OBJCOPY}"
 
-$targetpath/buildjdk/jdk/bin/jlink \
+jlink \
 --module-path=jdkout/jmods \
---add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.nio.mapmode,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs,jdk.incubator.vector$EXTRA_JLINK_OPTION \
+--add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.nio.mapmode,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs$EXTRA_JLINK_OPTION \
 --output jreout \
 $JLINK_STRIP_ARG \
 --no-man-pages \
 --no-header-files \
 --release-info=jdkout/release \
---compress=0
+--compress=0 
 
-cp freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT/lib/libfreetype.so jreout/lib/
-cp freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT/lib/libfreetype.so jdkout/lib/
+cp freetype/build_android-$TARGET_SHORT/lib/libfreetype.so jreout/lib/
+cp freetype/build_android-$TARGET_SHORT/lib/libfreetype.so jdkout/lib/
 
 # mv jreout/lib/${TARGET_JDK}/libfontmanager.diz jreout/lib/${TARGET_JDK}/libfontmanager.diz.keep
 # find jreout -name "*.debuginfo" | xargs -- rm

--- a/setdevkitpath.sh
+++ b/setdevkitpath.sh
@@ -2,11 +2,6 @@
 # https://github.com/PojavLauncherTeam/openjdk-multiarch-jdk8u/blob/aarch64-shenandoah-jdk8u272-b10/jdk/src/share/native/sun/java2d/loops/GraphicsPrimitiveMgr.c
 export NDK_VERSION=r25c
 
-if [[ -z "$BUILD_FREETYPE_VERSION" ]]
-then
-  export BUILD_FREETYPE_VERSION="2.13.2"
-fi
-
 if [[ -z "$JDK_DEBUG_LEVEL" ]]
 then
   export JDK_DEBUG_LEVEL=release
@@ -49,15 +44,17 @@ export thecc=$TOOLCHAIN/bin/${TARGET}${API}-clang
 export thecxx=$TOOLCHAIN/bin/${TARGET}${API}-clang++
 
 # Configure and build.
+export DLLTOOL=/usr/bin/llvm-dlltool-18
+export CXXFILT=$TOOLCHAIN/bin/llvm-cxxfilt
 export NM=$TOOLCHAIN/bin/llvm-nm
 export CC=$PWD/android-wrapped-clang
 export CXX=$PWD/android-wrapped-clang++
 export AR=$TOOLCHAIN/bin/llvm-ar
 export AS=$TOOLCHAIN/bin/llvm-as
-export LD=$TOOLCHAIN/bin/ld
+export LD=$TOOLCHAIN/bin/ld.lld
 export OBJCOPY=$TOOLCHAIN/bin/llvm-objcopy
+export OBJDUMP=$TOOLCHAIN/bin/llvm-objdump
 export READELF=$TOOLCHAIN/bin/llvm-readelf
 export RANLIB=$TOOLCHAIN/bin/llvm-ranlib
 export STRIP=$TOOLCHAIN/bin/llvm-strip
 export LINK=$TOOLCHAIN/bin/llvm-link
-

--- a/setdevkitpath.sh
+++ b/setdevkitpath.sh
@@ -2,6 +2,11 @@
 # https://github.com/PojavLauncherTeam/openjdk-multiarch-jdk8u/blob/aarch64-shenandoah-jdk8u272-b10/jdk/src/share/native/sun/java2d/loops/GraphicsPrimitiveMgr.c
 export NDK_VERSION=r26d
 
+if [[ -z "$BUILD_FREETYPE_VERSION" ]]
+then
+  export BUILD_FREETYPE_VERSION="2.13.2"
+fi
+
 if [[ -z "$JDK_DEBUG_LEVEL" ]]
 then
   export JDK_DEBUG_LEVEL=release

--- a/setdevkitpath.sh
+++ b/setdevkitpath.sh
@@ -1,6 +1,6 @@
 # Use the old NDK r10e to not get internal compile error at (still?)
 # https://github.com/PojavLauncherTeam/openjdk-multiarch-jdk8u/blob/aarch64-shenandoah-jdk8u272-b10/jdk/src/share/native/sun/java2d/loops/GraphicsPrimitiveMgr.c
-export NDK_VERSION=r25c
+export NDK_VERSION=r26d
 
 if [[ -z "$JDK_DEBUG_LEVEL" ]]
 then


### PR DESCRIPTION
1.使用ndk r26d build
2.伪装的gcc版本太低了，不给面子是吧
3.传递-flto=auto给CFLAGS(听说有优化)
4.修复补丁
5.引入一部分termux-package的补丁
6.使用最新版本的cups