### PR TITLE
21

### DIFF
--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -83,7 +83,7 @@ bash ./configure \
     --with-version-pre=- \
     --openjdk-target=$TARGET \
     --with-extra-cflags="$CFLAGS" \
-    --with-extra-cxxflags="$CFLAGS -D__ANDROID_API__=${API}" \
+    --with-extra-cxxflags="$CFLAGS -D__ANDROID_MIN_SDK_VERSION__=${API}" \
     --with-extra-ldflags="$LDFLAGS" \
     --disable-precompiled-headers \
     --disable-warnings-as-errors \

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -33,17 +33,23 @@ ln -s -f /usr/include/X11 $ANDROID_INCLUDE/
 ln -s -f /usr/include/fontconfig $ANDROID_INCLUDE/
 platform_args="--with-toolchain-type=gcc \
   --with-freetype-include=$FREETYPE_DIR/include/freetype2 \
-  --build=x86_64-unknown-linux-gnu \
   --with-freetype-lib=$FREETYPE_DIR/lib \
-  OBJCOPY=${OBJCOPY} \
-  RANLIB=${RANLIB} \
-  LINK=${LINK} \
-  AR=${AR} \
-  AS=${AS} \
-  NM=${NM} \
+  OBJDUMP=${OBJDUMP} \
   STRIP=${STRIP} \
-  READELF=${READELF} \
+  NM=${NM} \
+  AR=${AR} \
+  OBJCOPY=${OBJCOPY} \
+  CXXFILT=${CXXFILT} \
+  BUILD_NM=${NM} \
+  BUILD_AR=${AR} \
+  BUILD_LD=${LD} \
+  BUILD_OBJCOPY=${OBJCOPY} \
+  BUILD_STRIP=${STRIP} \
   "
+if [[ "$TARGET_JDK" == "x86" ]]; then
+    platform_args+="--build=x86_64-unknown-linux-gnu \
+    "
+fi
 AUTOCONF_x11arg="--x-includes=$ANDROID_INCLUDE/X11"
 AUTOCONF_EXTRA_ARGS+="OBJCOPY=$OBJCOPY \
   AR=$AR \
@@ -92,16 +98,6 @@ bash ./configure \
     --with-fontconfig-include=$ANDROID_INCLUDE \
     $AUTOCONF_x11arg $AUTOCONF_EXTRA_ARGS \
     --x-libraries=/usr/lib \
-    OBJDUMP=${OBJDUMP} \
-    STRIP=${STRIP} \
-    NM=${NM} \
-    AR=${AR} \
-    OBJCOPY=${OBJCOPY} \
-    CXXFILT=${CXXFILT} \
-    BUILD_NM=${NM} \
-    BUILD_AR=${AR} \
-    BUILD_OBJCOPY=${OBJCOPY} \
-    BUILD_STRIP=${STRIP} \
         $platform_args || \
 error_code=$?
 if [[ "$error_code" -ne 0 ]]; then

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -56,7 +56,7 @@ AUTOCONF_EXTRA_ARGS+="OBJCOPY=$OBJCOPY \
   STRIP=$STRIP \
   "
 
-export CFLAGS+=" -DANDROID -mllvm -polly"
+export CFLAGS+=" -mllvm -polly -DANDROID -D__ANDROID_API__=${API}"
 export LDFLAGS+=" -L$PWD/dummy_libs" 
 
 # Create dummy libraries so we won't have to remove them in OpenJDK makefiles

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -42,7 +42,6 @@ platform_args="--with-toolchain-type=gcc \
   CXXFILT=${CXXFILT} \
   BUILD_NM=${NM} \
   BUILD_AR=${AR} \
-  BUILD_LD=${LD} \
   BUILD_OBJCOPY=${OBJCOPY} \
   BUILD_STRIP=${STRIP} \
   "
@@ -83,7 +82,7 @@ bash ./configure \
     --with-version-pre=- \
     --openjdk-target=$TARGET \
     --with-extra-cflags="$CFLAGS" \
-    --with-extra-cxxflags="$CFLAGS -D__ANDROID_MIN_SDK_VERSION__=${API}" \
+    --with-extra-cxxflags="$CFLAGS" \
     --with-extra-ldflags="$LDFLAGS" \
     --disable-precompiled-headers \
     --disable-warnings-as-errors \

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -75,7 +75,7 @@ git apply --reject --whitespace=fix ../patches/jdk21u_android.diff || echo "git 
 #   --with-extra-cflags="$CPPFLAGS" \
 
 bash ./configure \
-    --with-version-pre=- \
+    --with-version-pre=" " \
     --openjdk-target=$TARGET \
     --with-extra-cflags="$CFLAGS" \
     --with-extra-cxxflags="$CFLAGS" \

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -56,7 +56,7 @@ AUTOCONF_EXTRA_ARGS+="OBJCOPY=$OBJCOPY \
   STRIP=$STRIP \
   "
 
-export CFLAGS+=" -mllvm -polly -DANDROID -D__ANDROID_API__=${API}"
+export CFLAGS+=" -mllvm -polly -DANDROID"
 export LDFLAGS+=" -L$PWD/dummy_libs" 
 
 # Create dummy libraries so we won't have to remove them in OpenJDK makefiles
@@ -83,7 +83,7 @@ bash ./configure \
     --with-version-pre=- \
     --openjdk-target=$TARGET \
     --with-extra-cflags="$CFLAGS" \
-    --with-extra-cxxflags="$CFLAGS" \
+    --with-extra-cxxflags="$CFLAGS -D__ANDROID_API__=${API}" \
     --with-extra-ldflags="$LDFLAGS" \
     --disable-precompiled-headers \
     --disable-warnings-as-errors \

--- a/buildjdk.sh
+++ b/buildjdk.sh
@@ -40,10 +40,6 @@ platform_args="--with-toolchain-type=gcc \
   AR=${AR} \
   OBJCOPY=${OBJCOPY} \
   CXXFILT=${CXXFILT} \
-  BUILD_NM=${NM} \
-  BUILD_AR=${AR} \
-  BUILD_OBJCOPY=${OBJCOPY} \
-  BUILD_STRIP=${STRIP} \
   "
 if [[ "$TARGET_JDK" == "x86" ]]; then
     platform_args+="--build=x86_64-unknown-linux-gnu \

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -314,10 +314,11 @@ index 42680218d..403d8905b 100644
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
 -#ifdef MUSL_LIBC
-+#if defined(MUSL_LIBC) || (defined(__ANDROID__) && __ANDROID_API__ < 24)
++#if defined(MUSL_LIBC) || defined(__ANDROID__)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
- static void *dlvsym(void *handle,
+-static void *dlvsym(void *handle,
++void *dlvsym(void *handle,
 @@ -214,6 +214,8 @@ static int clock_tics_per_sec = 100;
  // avoid this
  static bool suppress_primordial_thread_resolution = false;
@@ -2608,3 +2609,105 @@ index 7a24815..d20a9ff 100644
        fi
        UTIL_LOOKUP_PROGS(BUILD_NM, nm gcc-nm)
        UTIL_LOOKUP_PROGS(BUILD_AR, ar gcc-ar lib)
+diff --git a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
+--- a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
++++ b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
+@@ -31,41 +31,17 @@
+ #include "utilities/debug.hpp"
+
+ void ZNUMA::pd_initialize() {
+-  _enabled = UseNUMA;
++  _enabled = false;
+ }
+
+ uint32_t ZNUMA::count() {
+-  if (!_enabled) {
+-    // NUMA support not enabled
+-    return 1;
+-  }
++  return 1;
++}
+
+-  return os::Linux::numa_max_node() + 1;
+-}
+-
+ uint32_t ZNUMA::id() {
+-  if (!_enabled) {
+-    // NUMA support not enabled
+-    return 0;
+-  }
++  return 0;
++}
+
+-  return os::Linux::get_node_by_cpu(ZCPU::id());
+-}
+-
+ uint32_t ZNUMA::memory_id(uintptr_t addr) {
+-  if (!_enabled) {
+-    // NUMA support not enabled, assume everything belongs to node zero
+-    return 0;
+-  }
+-
+-  uint32_t id = (uint32_t)-1;
+-
+-  if (ZSyscall::get_mempolicy((int*)&id, nullptr, 0, (void*)addr, MPOL_F_NODE | MPOL_F_ADDR) == -1) {
+-    ZErrno err;
+-    fatal("Failed to get NUMA id for memory at " PTR_FORMAT " (%s)", addr, err.to_string());
+-  }
+-
+-  assert(id < count(), "Invalid NUMA id");
+-
+-  return id;
++  return 0;
+ }
+diff --git a/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp b/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp
+--- a/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp
++++ b/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp
+@@ -31,41 +31,17 @@
+ #include "utilities/debug.hpp"
+
+ void XNUMA::pd_initialize() {
+-  _enabled = UseNUMA;
++  _enabled = false;
+ }
+
+ uint32_t XNUMA::count() {
+-  if (!_enabled) {
+-    // NUMA support not enabled
+-    return 1;
+-  }
++  return 1;
++}
+
+-  return os::Linux::numa_max_node() + 1;
+-}
+-
+ uint32_t XNUMA::id() {
+-  if (!_enabled) {
+-    // NUMA support not enabled
+-    return 0;
+-  }
++  return 0;
++}
+
+-  return os::Linux::get_node_by_cpu(XCPU::id());
+-}
+-
+ uint32_t XNUMA::memory_id(uintptr_t addr) {
+-  if (!_enabled) {
+-    // NUMA support not enabled, assume everything belongs to node zero
+-    return 0;
+-  }
+-
+-  uint32_t id = (uint32_t)-1;
+-
+-  if (XSyscall::get_mempolicy((int*)&id, nullptr, 0, (void*)addr, MPOL_F_NODE | MPOL_F_ADDR) == -1) {
+-    XErrno err;
+-    fatal("Failed to get NUMA id for memory at " PTR_FORMAT " (%s)", addr, err.to_string());
+-  }
+-
+-  assert(id < count(), "Invalid NUMA id");
+-
+-  return id;
++  return 0;
+ }

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -314,7 +314,7 @@ index 42680218d..403d8905b 100644
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
 -#ifdef MUSL_LIBC
-+#if defined(MUSL_LIBC) || defined(__ANDROID__) && android_get_device_api_level() < 24)
++#if defined(MUSL_LIBC) || defined(__ANDROID__) && __ANDROID_API__ < 24)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
  static void *dlvsym(void *handle,
@@ -2573,3 +2573,22 @@ index 4ec11a136..01b85db4d 100644
  
      /*
       *  OK we may have the stack available in the kernel,
+diff --git a/make/autoconf/flags-cflags.m4 b/make/autoconf/flags-cflags.m4
+index c0626e8f9a45..3cd0550eb314 100644
+--- a/make/autoconf/flags-cflags.m4
++++ b/make/autoconf/flags-cflags.m4
+@@ -58,13 +58,7 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
+       SET_SHARED_LIBRARY_NAME='-Wl,-soname=[$]1'
+       SET_SHARED_LIBRARY_MAPFILE='-Wl,-version-script=[$]1'
+ 
+-      # arm specific settings
+-      if test "x$OPENJDK_TARGET_CPU" = "xarm"; then
+-        # '-Wl,-z,origin' isn't used on arm.
+-        SET_SHARED_LIBRARY_ORIGIN='-Wl,-rpath,\$$$$ORIGIN[$]1'
+-      else
+-        SET_SHARED_LIBRARY_ORIGIN="-Wl,-z,origin $SET_EXECUTABLE_ORIGIN"
+-      fi
++      SET_SHARED_LIBRARY_ORIGIN="-Wl,-z,origin $SET_EXECUTABLE_ORIGIN"
+     fi
+ 
+   elif test "x$TOOLCHAIN_TYPE" = xxlc; then

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -315,7 +315,7 @@ index 42680218d..403d8905b 100644
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
 -#ifdef MUSL_LIBC
-+#if defined(MUSL_LIBC) || (defined(__ANDROID__) && __ANDROID_API__ < 24)
++#if defined(MUSL_LIBC) || defined(__ANDROID__)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
  static void *dlvsym(void *handle,

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -16,14 +16,12 @@ diff --git a/make/autoconf/flags-ldflags.m4 b/make/autoconf/flags-ldflags.m4
 index 2aca285d3..494262487 100644
 --- a/make/autoconf/flags-ldflags.m4
 +++ b/make/autoconf/flags-ldflags.m4
-@@ -173,7 +173,9 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
+@@ -173,7 +173,8 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
         test "x${OPENJDK_$1_CPU}" = xmips64el; then
        $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      else
--      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
+       $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
 +      # Android 5.x does not support GNU hash style
-+      # gnu
-+      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      fi
  
    elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
@@ -316,7 +314,7 @@ index 42680218d..403d8905b 100644
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
 -#ifdef MUSL_LIBC
-+#if defined(MUSL_LIBC) || defined(__ANDROID__)
++#if defined(MUSL_LIBC) || defined(__ANDROID__) && android_get_device_api_level() < 24)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
  static void *dlvsym(void *handle,

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -20,8 +20,9 @@ index 2aca285d3..494262487 100644
         test "x${OPENJDK_$1_CPU}" = xmips64el; then
        $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      else
-       $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
+-      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
 +      # Android 5.x does not support GNU hash style
++      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      fi
  
    elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -16,12 +16,14 @@ diff --git a/make/autoconf/flags-ldflags.m4 b/make/autoconf/flags-ldflags.m4
 index 2aca285d3..494262487 100644
 --- a/make/autoconf/flags-ldflags.m4
 +++ b/make/autoconf/flags-ldflags.m4
-@@ -173,7 +173,8 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
+@@ -173,7 +173,9 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
         test "x${OPENJDK_$1_CPU}" = xmips64el; then
        $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      else
-       $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
+-      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
 +      # Android 5.x does not support GNU hash style
++      # gnu
++      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      fi
  
    elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
@@ -314,7 +316,7 @@ index 42680218d..403d8905b 100644
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
 -#ifdef MUSL_LIBC
-+#if defined(MUSL_LIBC) || defined(__ANDROID__)
++#if defined(MUSL_LIBC) || (defined(__ANDROID__) && __ANDROID_API__ < 24)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
 -static void *dlvsym(void *handle,

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -2553,3 +2553,23 @@ index 3b4a15b..1bca2bc 100644
      InitLauncher(javaw);
      DumpState();
      if (JLI_IsTraceLauncher()) {
+diff --git a/src/java.base/unix/native/libnet/net_util_md.c b/src/java.base/unix/native/libnet/net_util_md.c
+index 4ec11a136..01b85db4d 100644
+--- a/src/java.base/unix/native/libnet/net_util_md.c
++++ b/src/java.base/unix/native/libnet/net_util_md.c
+@@ -129,6 +129,7 @@ jint  IPv6_supported()
+     SOCKETADDRESS sa;
+     socklen_t sa_len = sizeof(SOCKETADDRESS);
+ 
++#ifndef __ANDROID__  // ANDROID: skip check, see libcore commit ae218d9b
+     fd = socket(AF_INET6, SOCK_STREAM, 0) ;
+     if (fd < 0) {
+         /*
+@@ -172,6 +173,7 @@ jint  IPv6_supported()
+         }
+     }
+ #endif
++#endif  // !defined __ANDROID__
+ 
+     /*
+      *  OK we may have the stack available in the kernel,

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -2592,18 +2592,3 @@ index c0626e8f9a45..3cd0550eb314 100644
      fi
  
    elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-diff --git a/make/autoconf/toolchain.m4 b/make/autoconf/toolchain.m4
-index 7a24815..d20a9ff 100644
---- a/make/autoconf/toolchain.m4
-+++ b/make/autoconf/toolchain.m4
-@@ -932,8 +932,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
-         UTIL_REQUIRE_PROGS(BUILD_CC, clang)
-         UTIL_REQUIRE_PROGS(BUILD_CXX, clang++)
-       else
--        UTIL_REQUIRE_PROGS(BUILD_CC, cc gcc)
--        UTIL_REQUIRE_PROGS(BUILD_CXX, CC g++)
-+        UTIL_REQUIRE_PROGS(BUILD_CC, clang gcc)
-+        UTIL_REQUIRE_PROGS(BUILD_CXX, clang++ g++)
-       fi
-       UTIL_LOOKUP_PROGS(BUILD_NM, nm gcc-nm)
-       UTIL_LOOKUP_PROGS(BUILD_AR, ar gcc-ar lib)

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -311,7 +311,7 @@ diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.c
 index 42680218d..403d8905b 100644
 --- a/src/hotspot/os/linux/os_linux.cpp
 +++ b/src/hotspot/os/linux/os_linux.cpp
-@@ -135,10 +135,10 @@
+@@ -135,7 +135,7 @@
  // for timer info max values which include all bits
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
@@ -319,11 +319,7 @@ index 42680218d..403d8905b 100644
 +#if defined(MUSL_LIBC) || (defined(__ANDROID__) && __ANDROID_API__ < 24)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
--static void *dlvsym(void *handle,
-+void *dlvsym(void *handle,
-                     const char *symbol,
-                     const char *version) {
-    // load the latest version of symbol
++static void *dlvsym(void *handle,
 @@ -214,6 +214,8 @@ static int clock_tics_per_sec = 100;
  // avoid this
  static bool suppress_primordial_thread_resolution = false;

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -314,7 +314,7 @@ index 42680218d..403d8905b 100644
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
 -#ifdef MUSL_LIBC
-+#if defined(MUSL_LIBC) || defined(__ANDROID__) && __ANDROID_API__ < 24)
++#if defined(MUSL_LIBC) || (defined(__ANDROID__) && __ANDROID_API__ < 24)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
  static void *dlvsym(void *handle,
@@ -2592,3 +2592,18 @@ index c0626e8f9a45..3cd0550eb314 100644
      fi
  
    elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+diff --git a/make/autoconf/toolchain.m4 b/make/autoconf/toolchain.m4
+index 7a24815..d20a9ff 100644
+--- a/make/autoconf/toolchain.m4
++++ b/make/autoconf/toolchain.m4
+@@ -932,8 +932,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
+         UTIL_REQUIRE_PROGS(BUILD_CC, clang)
+         UTIL_REQUIRE_PROGS(BUILD_CXX, clang++)
+       else
+-        UTIL_REQUIRE_PROGS(BUILD_CC, cc gcc)
+-        UTIL_REQUIRE_PROGS(BUILD_CXX, CC g++)
++        UTIL_REQUIRE_PROGS(BUILD_CC, clang gcc)
++        UTIL_REQUIRE_PROGS(BUILD_CXX, clang++ g++)
+       fi
+       UTIL_LOOKUP_PROGS(BUILD_NM, nm gcc-nm)
+       UTIL_LOOKUP_PROGS(BUILD_AR, ar gcc-ar lib)

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -2592,3 +2592,19 @@ index c0626e8f9a45..3cd0550eb314 100644
      fi
  
    elif test "x$TOOLCHAIN_TYPE" = xxlc; then
+
+diff --git a/make/autoconf/toolchain.m4 b/make/autoconf/toolchain.m4
+index 7a24815..d20a9ff 100644
+--- a/make/autoconf/toolchain.m4
++++ b/make/autoconf/toolchain.m4
+@@ -932,8 +932,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_SETUP_BUILD_COMPILERS],
+         UTIL_REQUIRE_PROGS(BUILD_CC, clang)
+         UTIL_REQUIRE_PROGS(BUILD_CXX, clang++)
+       else
+-        UTIL_REQUIRE_PROGS(BUILD_CC, cc gcc)
+-        UTIL_REQUIRE_PROGS(BUILD_CXX, CC g++)
++        UTIL_REQUIRE_PROGS(BUILD_CC, clang gcc)
++        UTIL_REQUIRE_PROGS(BUILD_CXX, clang++ g++)
+       fi
+       UTIL_LOOKUP_PROGS(BUILD_NM, nm gcc-nm)
+       UTIL_LOOKUP_PROGS(BUILD_AR, ar gcc-ar lib)

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -319,7 +319,7 @@ index 42680218d..403d8905b 100644
 +#if defined(MUSL_LIBC) || (defined(__ANDROID__) && __ANDROID_API__ < 24)
  // dlvsym is not a part of POSIX
  // and musl libc doesn't implement it.
-+static void *dlvsym(void *handle,
+ static void *dlvsym(void *handle,
 @@ -214,6 +214,8 @@ static int clock_tics_per_sec = 100;
  // avoid this
  static bool suppress_primordial_thread_resolution = false;

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -16,14 +16,12 @@ diff --git a/make/autoconf/flags-ldflags.m4 b/make/autoconf/flags-ldflags.m4
 index 2aca285d3..494262487 100644
 --- a/make/autoconf/flags-ldflags.m4
 +++ b/make/autoconf/flags-ldflags.m4
-@@ -173,7 +173,9 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
+@@ -173,7 +173,8 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_CPU_DEP],
         test "x${OPENJDK_$1_CPU}" = xmips64el; then
        $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      else
--      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
+       $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=gnu"
 +      # Android 5.x does not support GNU hash style
-+      # gnu
-+      $1_CPU_LDFLAGS="${$1_CPU_LDFLAGS} -Wl,--hash-style=sysv"
      fi
  
    elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
@@ -2610,105 +2608,3 @@ index 7a24815..d20a9ff 100644
        fi
        UTIL_LOOKUP_PROGS(BUILD_NM, nm gcc-nm)
        UTIL_LOOKUP_PROGS(BUILD_AR, ar gcc-ar lib)
-diff --git a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
---- a/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
-+++ b/src/hotspot/os/linux/gc/z/zNUMA_linux.cpp
-@@ -31,41 +31,17 @@
- #include "utilities/debug.hpp"
-
- void ZNUMA::pd_initialize() {
--  _enabled = UseNUMA;
-+  _enabled = false;
- }
-
- uint32_t ZNUMA::count() {
--  if (!_enabled) {
--    // NUMA support not enabled
--    return 1;
--  }
-+  return 1;
-+}
-
--  return os::Linux::numa_max_node() + 1;
--}
--
- uint32_t ZNUMA::id() {
--  if (!_enabled) {
--    // NUMA support not enabled
--    return 0;
--  }
-+  return 0;
-+}
-
--  return os::Linux::get_node_by_cpu(ZCPU::id());
--}
--
- uint32_t ZNUMA::memory_id(uintptr_t addr) {
--  if (!_enabled) {
--    // NUMA support not enabled, assume everything belongs to node zero
--    return 0;
--  }
--
--  uint32_t id = (uint32_t)-1;
--
--  if (ZSyscall::get_mempolicy((int*)&id, nullptr, 0, (void*)addr, MPOL_F_NODE | MPOL_F_ADDR) == -1) {
--    ZErrno err;
--    fatal("Failed to get NUMA id for memory at " PTR_FORMAT " (%s)", addr, err.to_string());
--  }
--
--  assert(id < count(), "Invalid NUMA id");
--
--  return id;
-+  return 0;
- }
-diff --git a/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp b/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp
---- a/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp
-+++ b/src/hotspot/os/linux/gc/x/xNUMA_linux.cpp
-@@ -31,41 +31,17 @@
- #include "utilities/debug.hpp"
-
- void XNUMA::pd_initialize() {
--  _enabled = UseNUMA;
-+  _enabled = false;
- }
-
- uint32_t XNUMA::count() {
--  if (!_enabled) {
--    // NUMA support not enabled
--    return 1;
--  }
-+  return 1;
-+}
-
--  return os::Linux::numa_max_node() + 1;
--}
--
- uint32_t XNUMA::id() {
--  if (!_enabled) {
--    // NUMA support not enabled
--    return 0;
--  }
-+  return 0;
-+}
-
--  return os::Linux::get_node_by_cpu(XCPU::id());
--}
--
- uint32_t XNUMA::memory_id(uintptr_t addr) {
--  if (!_enabled) {
--    // NUMA support not enabled, assume everything belongs to node zero
--    return 0;
--  }
--
--  uint32_t id = (uint32_t)-1;
--
--  if (XSyscall::get_mempolicy((int*)&id, nullptr, 0, (void*)addr, MPOL_F_NODE | MPOL_F_ADDR) == -1) {
--    XErrno err;
--    fatal("Failed to get NUMA id for memory at " PTR_FORMAT " (%s)", addr, err.to_string());
--  }
--
--  assert(id < count(), "Invalid NUMA id");
--
--  return id;
-+  return 0;
- }

--- a/patches/jdk21u_android.diff
+++ b/patches/jdk21u_android.diff
@@ -309,7 +309,7 @@ diff --git a/src/hotspot/os/linux/os_linux.cpp b/src/hotspot/os/linux/os_linux.c
 index 42680218d..403d8905b 100644
 --- a/src/hotspot/os/linux/os_linux.cpp
 +++ b/src/hotspot/os/linux/os_linux.cpp
-@@ -135,7 +135,7 @@
+@@ -135,10 +135,10 @@
  // for timer info max values which include all bits
  #define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
  
@@ -319,6 +319,9 @@ index 42680218d..403d8905b 100644
  // and musl libc doesn't implement it.
 -static void *dlvsym(void *handle,
 +void *dlvsym(void *handle,
+                     const char *symbol,
+                     const char *version) {
+    // load the latest version of symbol
 @@ -214,6 +214,8 @@ static int clock_tics_per_sec = 100;
  // avoid this
  static bool suppress_primordial_thread_resolution = false;

--- a/removejdkdebuginfo.sh
+++ b/removejdkdebuginfo.sh
@@ -3,7 +3,7 @@ set -e
 
 . setdevkitpath.sh
 
-imagespath=openjdk-${TARGET_VERSION}/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-${JDK_DEBUG_LEVEL}/images
+imagespath=openjdk/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-${JDK_DEBUG_LEVEL}/images
 
 rm -rf dizout jreout jdkout dSYM-temp
 mkdir -p dizout dSYM-temp/{lib,bin}

--- a/removejdkdebuginfo.sh
+++ b/removejdkdebuginfo.sh
@@ -3,14 +3,14 @@ set -e
 
 . setdevkitpath.sh
 
-targetpath=openjdk/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-${JDK_DEBUG_LEVEL}
+imagespath=openjdk-${TARGET_VERSION}/build/${JVM_PLATFORM}-${TARGET_JDK}-${JVM_VARIANTS}-${JDK_DEBUG_LEVEL}/images
 
 rm -rf dizout jreout jdkout dSYM-temp
 mkdir -p dizout dSYM-temp/{lib,bin}
 
-cp freetype-${BUILD_FREETYPE_VERSION}/build_android-$TARGET_SHORT/lib/libfreetype.so $targetpath/images/jdk/lib/
+cp freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT/lib/libfreetype.so $imagespath/jdk/lib/
 
-cp -r $targetpath/images/jdk jdkout
+cp -r $imagespath/jdk jdkout
 
 # JDK no longer create separate JRE image, so we have to create one manually.
 #mkdir -p jreout/bin
@@ -28,7 +28,7 @@ fi
 # Produce the jre equivalent from the jdk (https://blog.adoptium.net/2021/10/jlink-to-produce-own-runtime/)
 export JLINK_STRIP_ARG="--strip-native-debug-symbols=exclude-debuginfo-files:objcopy=${OBJCOPY}"
 
-$targetpath/buildjdk/jdk/bin/jlink \
+jlink \
 --module-path=jdkout/jmods \
 --add-modules java.base,java.compiler,java.datatransfer,java.desktop,java.instrument,java.logging,java.management,java.management.rmi,java.naming,java.net.http,java.prefs,java.rmi,java.scripting,java.se,java.security.jgss,java.security.sasl,java.sql,java.sql.rowset,java.transaction.xa,java.xml,java.xml.crypto,jdk.accessibility,jdk.charsets,jdk.crypto.cryptoki,jdk.crypto.ec,jdk.dynalink,jdk.httpserver,jdk.jdwp.agent,jdk.jfr,jdk.jsobject,jdk.localedata,jdk.management,jdk.management.agent,jdk.management.jfr,jdk.naming.dns,jdk.naming.rmi,jdk.net,jdk.nio.mapmode,jdk.sctp,jdk.security.auth,jdk.security.jgss,jdk.unsupported,jdk.xml.dom,jdk.zipfs,jdk.random$EXTRA_JLINK_OPTION \
 --output jreout \
@@ -36,10 +36,10 @@ $JLINK_STRIP_ARG \
 --no-man-pages \
 --no-header-files \
 --release-info=jdkout/release \
---compress=0
+--compress=0 
 
-cp freetype-${BUILD_FREETYPE_VERSION}/build_android-$TARGET_SHORT/lib/libfreetype.so jreout/lib/
-cp freetype-${BUILD_FREETYPE_VERSION}/build_android-$TARGET_SHORT/lib/libfreetype.so jdkout/lib/
+cp freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT/lib/libfreetype.so jreout/lib/
+cp freetype-$BUILD_FREETYPE_VERSION/build_android-$TARGET_SHORT/lib/libfreetype.so jdkout/lib/
 
 # mv jreout/lib/${TARGET_JDK}/libfontmanager.diz jreout/lib/${TARGET_JDK}/libfontmanager.diz.keep
 # find jreout -name "*.debuginfo" | xargs -- rm
@@ -49,5 +49,3 @@ cp freetype-${BUILD_FREETYPE_VERSION}/build_android-$TARGET_SHORT/lib/libfreetyp
 find jdkout -name "*.debuginfo" -exec mv {}   dizout/ \;
 
 find jdkout -name "*.dSYM"  | xargs -- rm -rf
-
-#TODO: fix .dSYM stuff

--- a/setdevkitpath.sh
+++ b/setdevkitpath.sh
@@ -26,7 +26,7 @@ fi
 
 export JVM_PLATFORM=linux
 # Set NDK
-export API=24
+export API=21
 
 # Runners usually ship with a recent NDK already
 if [[ -z "$ANDROID_NDK_HOME" ]]

--- a/setdevkitpath.sh
+++ b/setdevkitpath.sh
@@ -26,7 +26,7 @@ fi
 
 export JVM_PLATFORM=linux
 # Set NDK
-export API=21
+export API=24
 
 # Runners usually ship with a recent NDK already
 if [[ -z "$ANDROID_NDK_HOME" ]]


### PR DESCRIPTION
和buildjre17一样更倾向于clang
不区别对待aarch32(来自termux package的补丁)
去掉一些没必要的设置
ipv6(pojav团队已合并相关pr)